### PR TITLE
Update test files and schema for SMDL export development

### DIFF
--- a/export_test/layers/te5fp1ol.json
+++ b/export_test/layers/te5fp1ol.json
@@ -303,6 +303,8 @@
     "bib": [
         { 
             "id": "757c5dad-a4c0-4c61-a5ab-66c5ebb30a54", 
+            "shortcode": "Perria",
+            "citation": "Perria, Lidia. Repertorio dei manoscritti greci di area orientale, palestino-sinaitica. Messina, 2000",
             "type": { 
                 "id": "cite", 
                 "label": "Citation" 
@@ -325,7 +327,12 @@
         ],
         "rights": "UUnless otherwise indicated all metadata associated with this manuscript is copyright the authors and released under Creative Commons Attribution 4.0 International License."
     },
-    "internal": [ 
-        "Test record for development purposes; please delete." 
-    ] 
+    "cataloguer": [
+        {
+            "message": "ADDED: Ingested descriptions from the Syriac Parchment Descriptions project.",
+            "contributor": "Grigory Kessel; Natalia Smelova",
+            "added_by": "William Potter",
+            "timestamp": "2025-06-28T15:50:45+00:00"
+        }
+    ]
 }

--- a/export_test/layers/te5fp2ol.json
+++ b/export_test/layers/te5fp2ol.json
@@ -168,7 +168,12 @@
     "parent": [ 
         "ark:/21198/te5f0f9b" 
     ], 
-    "internal": [ 
-        "Test record for development purposes; please delete." 
-    ] 
+    "cataloguer": [
+        {
+            "message": "ADDED: Ingested descriptions from the Syriac Parchment Descriptions project.",
+            "contributor": "Grigory Kessel; Natalia Smelova",
+            "added_by": "William Potter",
+            "timestamp": "2025-06-03T15:50:45+00:00"
+        }
+    ]
 }

--- a/export_test/ms_objs/te5f0f9b.json
+++ b/export_test/ms_objs/te5f0f9b.json
@@ -346,7 +346,7 @@
             ], 
             "assoc_place": [
                 { 
-                    "id": "Nisibis", 
+                    "id": "ark:/21198/pl1234", 
                     "as_written": "ܢܨܝܒܝܢ", 
                     "event": { 
                         "id": "unknown", 
@@ -357,7 +357,7 @@
                     ] 
                 }, 
                 { 
-                    "id": "Amid", 
+                    "id": "ark:/21198/pl5678", 
                     "as_written": "ܐܡܕ", 
                     "event": { 
                         "id": "birth", 
@@ -390,7 +390,6 @@
             ] 
         } 
     ], 
-    "has_bind": true, 
     "location": [
         { 
             "id": "sinai-oc", 
@@ -536,6 +535,8 @@
     "bib": [
         { 
             "id": "deb668b6-feec-4828-8749-a97441881226", 
+            "shortcode": "Kamil",
+            "citation": "Kāmil, Murād. Catalogue of All Manuscripts in the Monastery of St. Catherine on Mount Sinai. Harrassowitz, 1970.",
             "type": { 
                 "id": "ref", 
                 "label": "Reference Work" 
@@ -548,6 +549,8 @@
         }, 
         {
             "id": "ce9cdae8-81ce-4c29-8431-ab599cd5491c",
+            "shortcode": "Gvaramia, et al. 1987",
+            "citation": "R. Gvaramia, E. Met'reveli, C. Č'ank'ievi, L. Xevsuriani, and L. Džġamaia. Kartul xelnacerta aġc'eriloba: Sinuri k'olekcia [Description of Georgian manuscripts: Sinai collection III]. Tbilisi, 1987",
             "type": {
                 "id": "ref",
                 "label": "Reference Work"
@@ -559,6 +562,8 @@
         },
         { 
             "id": "ec7c937f-655a-4459-b327-3793637b9db9", 
+            "shortcode": "LOC",
+            "citation": "Manuscripts in St. Catherine's Monastery, Mount Sinai. Library of Congress.",
             "type": { 
                 "id": "otherdigversion", 
                 "label": "Other Digital Version" 
@@ -570,6 +575,8 @@
         } ,
         {
             "id": "467167dd-e012-4f87-a1c8-cd8a79c3e8d5",
+            "shortcode": "Géhin 2006",
+            "citation": "Géhin, Paul. “Manuscrits sinaïtiques dispersés, I:  les fragments arabes et syriaques de Paris.” OC 90 (2006): 23-43",
             "type": {
                 "id": "cite",
                 "label": "Citation"
@@ -578,21 +585,22 @@
         },
         {
             "id": "6e8ae70b-30a1-4bff-87d8-69a54cdc3a7b",
+            "shortcode": "Gippert",
+            "citation": "J. Gippert. “New Perspectives of (Multi-)Spectral Manuscript Analysis,\" Pages 165–176 and [331–350] in C. Brockmann, D. Deckers, Daniel, L. Koch, Lutz, and S. Valente, eds. Handschriften-und Textforschung heute: Zur Überlieferung der griechischen Literatur. Festschrift für Dieter Harlfinger aus Anlass seines 70. Geburtstages. Serta Graeca 30. Wiesbaden, 2014",
             "type": {
                 "id": "cite",
                 "label": "Citation"
             }
         },
         {
-            "id": "5256f5da-f751-4cdc-85ce-35b9b20ae818",
+            "id": "f3ea9df2-bf85-465c-ac1d-6bd4cce71e21",
+            "shortcode": "NLI",
+            "citation": "Manuscripts in the Holy Monastery of St. Catherine at Mount Sinai. National Library of Israel",
             "type": {
                 "id": "otherdigversion",
                 "label": "Other Digital Version"
             },
-            "url": "https://www.nli.org.il/en/manuscripts/NNL_ALEPH990038917380205171/NLI",
-            "note": [
-                "Using CPG ID for dev purposes since we are missing a bibl for NLI..."
-            ]
+            "url": "https://www.nli.org.il/en/manuscripts/NNL_ALEPH990038917380205171/NLI"
         }
     ], 
     "iiif": [
@@ -652,7 +660,12 @@
         ],
         "rights": "Contact the Monastery of St. Catherine's of the Sinai."
     },
-    "internal": [ 
-        "This record is used only for purposes of developing the data portal and should therefore not be published, and should be deleted when development is complete" 
-    ] 
+    "cataloguer": [
+        {
+            "message": "ADDED: Ingested descriptions from the Syriac Parchment Descriptions project.",
+            "contributor": "Grigory Kessel; Natalia Smelova",
+            "added_by": "William Potter",
+            "timestamp": "2025-06-30T15:50:45+00:00"
+        }
+    ]
 }

--- a/export_test/places/pl1234.json
+++ b/export_test/places/pl1234.json
@@ -1,0 +1,9 @@
+{
+    "ark": "ark:/21198/pl1234",
+    "pref_name": "Nisibis",
+    "alt_name": [
+        "ܢܨܝܒܝܢ",
+        "Nusaybin",
+        "Ṣōbā"
+    ]
+}

--- a/export_test/places/pl5678.json
+++ b/export_test/places/pl5678.json
@@ -1,0 +1,4 @@
+{
+    "ark": "ark:/21198/pl5678",
+    "pref_name": "Amid"
+}

--- a/export_test/smdl-schema.json
+++ b/export_test/smdl-schema.json
@@ -12,14 +12,11 @@
             "type": "boolean"
         },
         "type": {
-            "type": "string"
+            "$ref": "#/$defs/controlled_term"
         },
         "shelfmark": {
             "type": "string",
             "minLength": 1
-        },
-        "ms_date": {
-            "$ref": "#/$defs/aggregated_date"
         },
         "summary": {
             "type": "string"
@@ -34,7 +31,7 @@
             "type": "string"
         },
         "state": {
-            "type": "string"
+            "$ref": "#/$defs/controlled_term"
         },
         "fol": {
             "type": "string"
@@ -42,17 +39,10 @@
         "coll": {
             "type": "string"
         },
-        "genre": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "unevaluatedItems": false
-        },
         "features": {
             "type": "array",
             "items": {
-                "type": "string"
+                "$ref": "#/$defs/controlled_term"
             },
             "unevaluatedItems": false
         },
@@ -99,6 +89,9 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "type": "string"
+                    },
                     "repository": {
                         "type": "string"
                     },
@@ -107,6 +100,7 @@
                     }
                 },
                 "required": [
+                    "id",
                     "repository"
                 ],
                 "unevaluatedProperties": false
@@ -141,7 +135,7 @@
                 "type": "object",
                 "properties": {
                     "type": {
-                        "type": "string"
+                        "$ref": "#/$defs/controlled_term"
                     },
                     "label": {
                         "type": "string"
@@ -163,23 +157,7 @@
         "bib": {
             "type": "array",
             "items": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "properties": {
-                            "type": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    {
-                        "$ref": "#/$defs/bib"
-                    }
-                ],
-                "unevaluatedProperties": false
+                "$ref": "#/$defs/bib"
             },
             "unevaluatedItems": false
         },
@@ -200,6 +178,12 @@
                         "format": "uri"
                     },
                     "type": {
+                        "$ref": "#/$defs/controlled_term"
+                    },
+                    "text_direction": {
+                        "type": "string"
+                    },
+                    "behavior": {
                         "type": "string"
                     },
                     "thumbnail": {
@@ -215,41 +199,8 @@
             },
             "unevaluatedItems": false
         },
-        "cataloguer": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "unevaluatedItems": false
-        },
         "desc_provenance": {
-            "type": "object",
-            "properties": {
-                "program": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "label": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "label",
-                            "description"
-                        ],
-                        "unevaluatedProperties": false
-                    },
-                    "unevaluatedItems": false
-                },
-                "rights": {
-                    "type": "string"
-                }
-            },
-            "unevaluatedProperties": false
+            "$ref": "#/$defs/desc_provenance"
         },
         "image_provenance": {
             "type": "object",
@@ -316,9 +267,12 @@
             },
             "unevaluatedItems": false
         },
-        "last_modified": {
-            "type": "string",
-            "format": "date"
+        "cataloguer": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/cataloguer"
+            },
+            "unevaluatedItems": false
         }
     },
     "required": [
@@ -330,11 +284,32 @@
         "state",
         "part",
         "location",
-        "iiif",
-        "last_modified"
+        "iiif"
     ],
     "unevaluatedProperties": false,
     "$defs": {
+        "agent_record": {
+            "type": "object",
+            "properties": {
+                "ark": {
+                    "$ref": "#/$defs/ark"
+                },
+                "pref_name": {
+                    "type": "string"
+                },
+                "alt_name": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "unevaluatedItems": false
+                }
+            },
+            "required": [
+                "ark",
+                "pref_name"
+            ]
+        },
         "aggregated_date": {
             "type": "object",
             "properties": {
@@ -382,10 +357,25 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "value": {
                     "type": "string"
+                },
+                "iso": {
+                    "type": "object",
+                    "properties": {
+                        "not_before": {
+                            "type": "string"
+                        },
+                        "not_after": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "not_before"
+                    ],
+                    "unevaluatedProperties": false
                 },
                 "as_written": {
                     "type": "string"
@@ -406,8 +396,11 @@
         "assoc_name": {
             "type": "object",
             "properties": {
-                "pref_name": {
-                    "type": "string"
+                "id": {
+                    "$ref": "#/$defs/ark"
+                },
+                "agent_record": {
+                    "$ref": "#/$defs/agent_record"
                 },
                 "value": {
                     "type": "string"
@@ -416,7 +409,7 @@
                     "type": "string"
                 },
                 "role": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "note": {
                     "type": "array",
@@ -434,8 +427,11 @@
         "assoc_place": {
             "type": "object",
             "properties": {
-                "pref_name": {
-                    "type": "string"
+                "id": {
+                    "$ref": "#/$defs/ark"
+                },
+                "place_record": {
+                    "$ref": "#/$defs/place_record"
                 },
                 "value": {
                     "type": "string"
@@ -444,7 +440,7 @@
                     "type": "string"
                 },
                 "event": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "note": {
                     "type": "array",
@@ -462,8 +458,17 @@
         "bib": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "shortcode": {
                     "type": "string"
+                },
+                "citation": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "range": {
                     "type": "string"
@@ -484,17 +489,122 @@
                 }
             },
             "required": [
-                "shortcode"
+                "id",
+                "shortcode",
+                "citation",
+                "type"
             ]
         },
+        "cataloguer": {
+            "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "contributor": {
+                        "type": "string"
+                    },
+                    "added_by": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "message",
+                    "added_by",
+                    "timestamp"
+                ],
+                "unevaluatedProperties": false
+        },
+        "controlled_term": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "label"
+            ],
+            "unevaluatedProperties": false
+        },
+        "desc_provenance": {
+            "type": "object",
+            "properties": {
+                "program": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "label",
+                            "description"
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    "unevaluatedItems": false
+                },
+                "rights": {
+                    "type": "string"
+                }
+            },
+            "unevaluatedProperties": false
+        },
         "layer": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/ark"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/$defs/controlled_term"
+                },
+                "locus": {
+                    "type": "string"
+                },
+                "layer_record": {
+                    "$ref": "#/$defs/layer_record"
+                }
+            },
+            "required": [
+                "id",
+                "label",
+                "type",
+                "layer_record"
+            ],
+            "unevaluatedProperties": false
+        },
+        "layer_record": {
             "type": "object",
             "properties": {
                 "ark": {
                     "$ref": "#/$defs/ark"
                 },
-                "origin_date": {
-                    "$comment": "TBD: is this an aggregated date, just iso, just value?"
+                "reconstruction": {
+                    "type": "boolean"
+                },
+                "state": {
+                    "$ref": "#/$defs/controlled_term"
+                },
+                "label": {
+                    "type": "string"
                 },
                 "locus": {
                     "type": "string"
@@ -597,7 +707,27 @@
                 "text_unit": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/text_unit"
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "$ref": "#/$defs/ark"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "locus": {
+                                "type": "string"
+                            },
+                            "text_unit_record": {
+                                "$ref": "#/$defs/text_unit"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "label",
+                            "text_unit_record"
+                        ],
+                        "unevaluatedProperties": false
                     },
                     "minItems": 1,
                     "unevaluatedItems": false
@@ -606,6 +736,13 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/paracontent"
+                    },
+                    "unevaluatedItems": false
+                },
+                "features": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/controlled_term"
                     },
                     "unevaluatedItems": false
                 },
@@ -636,12 +773,52 @@
                         "$ref": "#/$defs/typed_note"
                     },
                     "unevaluatedItems": false
+                },
+                "related_mss": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/related_mss"
+                    },
+                    "unevaluatedItems": false
+                },
+                "bib": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/bib"
+                    },
+                    "unevaluatedItems": false
+                },
+                "desc_provenance": {
+                    "$ref": "#/$defs/desc_provenance"
+                },
+                "cataloguer": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/cataloguer"
+                    },
+                    "unevaluatedItems": false
+                },
+                "parent": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ark"
+                    }
+                },
+                "reconstructed_from": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ark"
+                    }
                 }
             },
             "required": [
                 "ark",
+                "reconstruction",
+                "state",
+                "label",
                 "writing",
-                "text_unit"
+                "text_unit",
+                "parent"
             ],
             "unevaluatedProperties": false
         },
@@ -649,7 +826,7 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "label": {
                     "type": "string"
@@ -668,7 +845,7 @@
                 "lang": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/$defs/controlled_term"
                     },
                     "minItems": 1,
                     "unevaluatedItems": false
@@ -728,16 +905,13 @@
                 "summary": {
                     "type": "string"
                 },
-                "part_date": {
-                    "$ref": "#/$defs/aggregated_date"
-                },
                 "locus": {
                     "type": "string"
                 },
                 "support": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/$defs/controlled_term"
                     },
                     "minItems": 1,
                     "unevaluatedItems": false
@@ -779,6 +953,13 @@
                     },
                     "unevaluatedItems": false
                 },
+                "related_mss": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/related_mss"
+                    },
+                    "unevaluatedItems": false
+                },
                 "note": {
                     "type": "array",
                     "items": {
@@ -793,11 +974,33 @@
             ],
             "unevaluatedProperties": false
         },
+        "place_record": {
+            "type": "object",
+            "properties": {
+                "ark": {
+                    "$refs": "#/$defs/ark"
+                },
+                "pref_name": {
+                    "type": "string"
+                },
+                "alt_name": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "unevaluatedItems": false
+                }
+            },
+            "required": [
+                "ark",
+                "pref_name"
+            ]
+        },
         "related_mss": {
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "label": {
                     "type": "string"
@@ -844,16 +1047,20 @@
         "script": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "label": {
                     "type": "string"
                 },
-                "system": {
+                "writing_system": {
                     "type": "string"
                 }
             },
             "required": [
-                "script",
-                "system"
+                "id",
+                "label",
+                "writing_system"
             ],
             "unevaluatedProperties": false
         },
@@ -862,6 +1069,12 @@
             "properties": {
                 "ark": {
                     "$ref": "#/$defs/ark"
+                },
+                "reconstruction": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
                 },
                 "locus": {
                     "type": "string"
@@ -872,7 +1085,7 @@
                 "lang": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/$defs/controlled_term"
                     },
                     "minItems": 1,
                     "unevaluatedItems": false
@@ -880,122 +1093,7 @@
                 "work_wit": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "properties": {
-                            "locus": {
-                                "type": "string"
-                            },
-                            "pref_title": {
-                                "type": "string"
-                            },
-                            "descriptive_title": {
-                                "type": "string"
-                            },
-                            "alt_title": {
-                                "type": "string"
-                            },
-                            "as_written": {
-                                "type": "string"
-                            },
-                            "creator": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "pref_name": {
-                                            "type": "string"
-                                        },
-                                        "role": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "pref_name"
-                                    ],
-                                    "unevaluatedProperties": false
-                                },
-                                "unevaluatedItems": false
-                            },
-                            "excerpt": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string"
-                                        },
-                                        "locus": {
-                                            "type": "string"
-                                        },
-                                        "as_written": {
-                                            "type": "string"
-                                        },
-                                        "translation": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "unevaluatedItems": false
-                                        },
-                                        "note": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "unevaluatedItems": false
-                                        }
-                                    },
-                                    "required": [
-                                        "type",
-                                        "locus"
-                                    ],
-                                    "unevaluatedProperties": false
-                                },
-                                "unevaluatedItems": false
-                            },
-                            "contents": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "pref_title": {
-                                            "type": "string"
-                                        },
-                                        "descriptive_title": {
-                                            "type": "string"
-                                        },
-                                        "locus": {
-                                            "type": "string"
-                                        },
-                                        "note": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "unevaluatedItems": false
-                                        }
-                                    },
-                                    "unevaluatedProperties": false
-                                },
-                                "unevaluatedItems": false
-                            },
-                            "edition": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/$defs/bib",
-                                    "unevaluatedProperties": false
-                                },
-                                "unevaluatedItems": false
-                            },
-                            "note": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "unevaluatedItems": false
-                            }
-                        },
-                        "unevaluatedProperties": false
+                        "$ref": "#/$defs/work_witness"
                     },
                     "minItems": 1,
                     "unevaluatedItems": false
@@ -1007,6 +1105,13 @@
                     },
                     "unevaluatedItems": false
                 },
+                "features": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/controlled_term"
+                    },
+                    "unevaluatedItems": false
+                },
                 "note": {
                     "type": "array",
                     "items": {
@@ -1014,19 +1119,46 @@
                     },
                     "unevaluatedItems": false
                 },
-                "edition": {
+                "bib": {
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/bib",
                         "unevaluatedProperties": false
                     },
                     "unevaluatedItems": false
+                },
+                "desc_provenance": {
+                    "$ref": "#/$defs/desc_provenance"
+                },
+                "cataloguer": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/cataloguer"
+                    },
+                    "unevaluatedItems": false
+                },
+                "reconstructed_from": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ark"
+                    },
+                    "unevaluatedItems": false
+                },
+                "parent": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ark"
+                    },
+                    "unevaluatedItems": false
                 }
             },
             "required": [
                 "ark",
+                "reconstruction",
+                "label",
                 "lang",
-                "work_wit"
+                "work_wit",
+                "parent"
             ],
             "unevaluatedProperties": false
         },
@@ -1034,7 +1166,7 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string"
+                    "$ref": "#/$defs/controlled_term"
                 },
                 "value": {
                     "type": "string"
@@ -1078,7 +1210,24 @@
                     "unevaluatedItems": false
                 },
                 "orig_date": {
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string"
+                        },
+                        "iso": {
+                            "type": "object",
+                            "properties": {
+                                "not_before": {
+                                    "type": "string"
+                                },
+                                "not_after": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "unevaluatedProperties": false
                 }
             },
             "required": [
@@ -1086,7 +1235,176 @@
                 "label",
                 "script",
                 "lang"
-            ]
+            ],
+            "unevaluatedProperties": false
+        },
+        "work_record": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/ark"
+                },
+                "pref_title": {
+                    "type": "string"
+                },
+                "desc_title": {
+                    "type": "string"
+                },
+                "alt_title": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "unevaluatedItems": false
+                },
+                "creator": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "$ref": "#/$defs/ark"
+                            },
+                            "agent_record": {
+                                "$refs": "#/$defs/agent_record"
+                            },
+                            "role": {
+                                "$ref": "#/$defs/controlled_term"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "agent_record"
+                        ]
+                    },
+                    "unevaluatedItems": false
+                },
+                "genre": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/controlled_term"
+                    },
+                    "unevaluatedItems": false     
+                },
+                "refno": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "idno": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "label",
+                        "idno",
+                        "source"
+                    ],
+                    "unevaluatedProperties": false
+                }
+            }
+        },
+        "work_witness": {
+            "type": "object",
+                "properties": {
+                    "locus": {
+                        "type": "string"
+                    },
+                    "work": {
+                        "$ref": "#/$defs/work_record"
+                    },
+                    "alt_title": {
+                        "type": "string"
+                    },
+                    "as_written": {
+                        "type": "string"
+                    },
+                    "excerpt": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "$ref": "#/$defs/controlled_term"
+                                },
+                                "locus": {
+                                    "type": "string"
+                                },
+                                "as_written": {
+                                    "type": "string"
+                                },
+                                "translation": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "unevaluatedItems": false
+                                },
+                                "note": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "unevaluatedItems": false
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "unevaluatedProperties": false
+                        },
+                        "unevaluatedItems": false
+                    },
+                    "contents": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "work_id": {
+                                    "$ref": "#/$defs/ark"
+                                },
+                                "pref_title": {
+                                    "type": "string"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "locus": {
+                                    "type": "string"
+                                },
+                                "note": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "unevaluatedItems": false
+                                }
+                            },
+                            "unevaluatedProperties": false
+                        },
+                        "unevaluatedItems": false
+                    },
+                    "bib": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/bib",
+                            "unevaluatedProperties": false
+                        },
+                        "unevaluatedItems": false
+                    },
+                    "note": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "unevaluatedItems": false
+                    }
+                },
+                "unevaluatedProperties": false
         }
     }
 }

--- a/export_test/text_units/te5fp1olt1.json
+++ b/export_test/text_units/te5fp1olt1.json
@@ -13,7 +13,7 @@
     "work_wit": [
         {
             "work": {
-                "id": "ark:/21198/s1h30c"
+                "id": "ark:/21198/s1gc7g"
             },
             "alt_title": "Synaxarion for the whole year according to the rite of the Greeks",
             "as_written": "ܣܘܢܟܣܪܝܢ ܕܫܢܬܐ ܟܠܗ̇ ܐܝܟ ܛܟܣܐ ܕܝܘ̈ܢܝܐ",
@@ -78,6 +78,8 @@
             "bib": [
                 {
                     "id": "01d4a639-d314-4271-b7f8-3f559c6c744c",
+                    "shortcode": "Kashouh 2012",
+                    "citation": "Kashouh, Hikmat. The Arabic Versions of the Gospels: The Manuscripts and their Families. Berlin: De Gruyter, 2012",
                     "type": {
                         "id": "edition",
                         "label": "Edition"
@@ -175,30 +177,25 @@
     "bib": [
         {
             "id": "3a20a9e1-0b02-476c-966e-649b62ac5761",
+            "shortcode": "Binggeli",
+            "citation": "Binggeli, André. \"Les trois David copistes arabes de Palestine aux 9e-10e s.” In Manuscripta graeca et orientalia: Mélanges monastiques et patristiques en l’honneur de Paul Géhin. Edited by André Binggeli, Anne Boud'hors, and Matthieu Cassin, 79-118. Leuven: Peeters, 2016.",
             "type": {
                 "id": "cite",
                 "label": "Citation"
             },
-            "range": "pp. 43-687",
-            "note": [
-                "Binggeli"
-            ]
+            "range": "pp. 43-687"
         },
         {
             "id": "afba79a3-c57f-44cf-9005-ed6e2f3d76b8",
+            "shortcode": "Müller-Kessler 2017",
+            "citation": "C. Müller-Kessler. “The Martyrdom of Arianos and the Four Protectores in an Unpublished Christian Palestinian Aramaic Palimpsest, St Catherine’s Monastery (Sinai, Arabic NF 66).” Collectanea Christiana Orientalia 14 (2017): 115-125. https://doi.org/10.21071/cco.v14i.14448",
             "type": {
                 "id": "edition",
                 "label": "Edition"
-            },
-            "note": [
-                "Müller-Kessler 2017"
-            ]
+            }
         }
     ],
     "parent": [
         "ark:/21198/te5fp1ol"
-    ],
-    "internal": [
-        "Test record, delete after development is complete"
-        ]
+    ]
 }

--- a/export_test/text_units/te5fp2olt1.json
+++ b/export_test/text_units/te5fp2olt1.json
@@ -13,7 +13,21 @@
     "work_wit": [
         {
             "work": {
-                "id": "ark:/21198/s1k88r"
+                "desc_title": "Arsenius of Scetis' Commentary on the Pandectes of Antiochus of Palestine",
+                "creator": [
+                    "ark:/21198/s13010",
+                    "ark:/21198/s1kw2p"
+                ],
+                "genre": [
+                    {
+                        "id": "commentaries",
+                        "label": "Commentaries"
+                    },
+                    {
+                        "id": "theological-works",
+                        "label": "Theological works"
+                      }
+                ]
             },
             "as_written": "ܐܘܢܓܠܝܘܢ [ܩܕ]ܝܫܐ ܟܪܘܙܘܬܐ [ܕ]ܠ[ܘ]ܩܐ",
             "locus": "ff. 55v-144v",


### PR DESCRIPTION
@sourcefilter this PR updates the input test records (in `export_test`) to make sure we have full coverage of all of the test cases we might have in the Portal json records for the SMDL export.

I've also added the most recent version of the JSON schema, updated based on how we've changed our thinking for many of the fields.